### PR TITLE
Fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,4 +21,3 @@ jobs:
       uses: ./.github/actions/common-tasks
       with:
         codecov_token: ${{ secrets.CODECOV_TOKEN }}
-


### PR DESCRIPTION
Potential fix for [https://github.com/mhagnumdw/vscode-easy-toggle-settings/security/code-scanning/3](https://github.com/mhagnumdw/vscode-easy-toggle-settings/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout@v4` and `./.github/actions/common-tasks`), the workflow likely only needs `contents: read` permissions. If additional permissions are required for specific tasks, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
