### PR TITLE
feat: Add support for workspace-level setting toggles

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,18 +1,29 @@
 import { defineConfig } from '@vscode/test-cli';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
 
 const tempUserDataDir = join(
   tmpdir(),
   `vscode-test-${Math.random().toString(36).slice(2)}`
 );
 
-// vscode-extension-test-runner does not work with console.log
+const workspaceFolder = join(
+  tmpdir(),
+  `vscode-test-workspace-${Math.random().toString(36).slice(2)}`
+);
+
+if (!existsSync(workspaceFolder)) {
+  console.log(`Creating test workspace directory: ${workspaceFolder}`);
+  mkdirSync(workspaceFolder, { recursive: true });
+}
+
 console.log(`Using temporary user data directory for vscode: ${tempUserDataDir}`);
+console.log(`Using test workspace directory: ${workspaceFolder}`);
 
 export default defineConfig({
   files: 'out/test/**/*.test.js',
-  workspaceFolder: 'out/test-workspace',
+  workspaceFolder: workspaceFolder,
   launchArgs: [
     '--user-data-dir=' + tempUserDataDir,
   ],

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -12,6 +12,7 @@ console.log(`Using temporary user data directory for vscode: ${tempUserDataDir}`
 
 export default defineConfig({
   files: 'out/test/**/*.test.js',
+  workspaceFolder: 'out/test-workspace',
   launchArgs: [
     '--user-data-dir=' + tempUserDataDir,
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "easy-toggle-settings" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 1.3.0
+
+- Feat: Add support for workspace-level setting toggles with the `isWorkspace` property (PR #80)
+
 ## 1.2.1
 
 - Fix: Unable to toggle settings with array/object values (PR #69)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For example, let's say we want to toggle these settings:
 
 - `editor.codeLens` between `true` and `false`
 - `editor.renderWhitespace` between `"none"` and `"all"`
+- `java.autobuild.enabled` between `true` and `false` at the workspace level
 
 Open global settings (`Ctrl Shift P > Open user settings json`) and add at the end:
 
@@ -39,6 +40,12 @@ Open global settings (`Ctrl Shift P > Open user settings json`) and add at the e
     "property": "editor.renderWhitespace",
     "icon": "whitespace",
     "values": ["none", "all"]
+  },
+  {
+    "property": "java.autobuild.enabled",
+    "icon": "rocket",
+    "values": [true, false],
+    "isWorkspace": true
   }
 ]
 ```
@@ -63,6 +70,7 @@ This extension contributes the following settings:
   - `property` (`string`): Full name of any vscode setting (e.g., `editor.codeLens`)
   - `icon` (`string`): [Codicon](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing) icon name (e.g., `eye`, `whitespace`)
   - `values` (`array`): At least two unique values to cycle through
+  - `isWorkspace` (`boolean`, optional): Toggles the setting at the workspace level instead of globally (default: `false`)
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
                 "type": "string",
                 "description": "Codicon icon name (e.g., eye, settings, debug)"
               },
+              "isWorkspace": {
+                "type": "boolean",
+                "description": "If true, the setting will be toggled at the workspace level instead of globally",
+                "default": false
+              },
               "values": {
                 "type": "array",
                 "description": "List of possible values for this setting",

--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -18,6 +18,8 @@ export interface ToggleSetting {
   values: any[];
   /** The icon to display in the status bar */
   icon: string;
+  /** If true, the setting will be toggled at the workspace level */
+  isWorkspace?: boolean;
 }
 
 /**
@@ -170,7 +172,9 @@ export class ExtensionManager {
     const currentIndex = setting.values.findIndex(value => JSON.stringify(value) === JSON.stringify(currentValue));
     const newValue = setting.values[(currentIndex + 1) % setting.values.length];
 
-    config.update(setting.property, newValue, vscode.ConfigurationTarget.Global).then(() => {
+    const target = setting.isWorkspace ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global;
+
+    config.update(setting.property, newValue, target).then(() => {
       this.updateStatusBarItem(setting, item);
     }, (err) => {
       const msg = `Failed to update setting ${setting.property}: ${err}`;

--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -186,8 +186,9 @@ export class ExtensionManager {
   private updateStatusBarItem(setting: ToggleSetting, item: vscode.StatusBarItem) {
     const config = vscode.workspace.getConfiguration();
     const value = config.get(setting.property);
+    const suffix = setting.isWorkspace ? ' (workspace)' : '';
     item.text = `$(${setting.icon})`;
-    item.tooltip = `${setting.property}: ${value}`;
+    item.tooltip = `${setting.property}: ${value}${suffix}`;
     item.show();
   }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -76,6 +76,19 @@ suite('Extension Test Suite', () => {
     assert.deepStrictEqual(extension.getValueFromConf('editor.rulers'), []);
   });
 
+  test('Add workspace toggle and rotate it', async () => {
+    await extension.addToggle('editor.renderWhitespace', 'whitespace', ["none", "all"], true);
+
+    await extension.click('editor.renderWhitespace');
+    assert.strictEqual(extension.getWorkspaceValueFromConf('editor.renderWhitespace'), 'none');
+
+    await extension.click('editor.renderWhitespace');
+    assert.strictEqual(extension.getWorkspaceValueFromConf('editor.renderWhitespace'), 'all');
+
+    await extension.click('editor.renderWhitespace');
+    assert.strictEqual(extension.getWorkspaceValueFromConf('editor.renderWhitespace'), 'none');
+  });
+
   test('Add duplicate toggle', async () => {
     const showWarningMessageSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
@@ -155,9 +168,9 @@ suite('Extension Test Suite', () => {
 class TestExtensionManager {
 
   /** Simulate the user adding a toggle */
-  async addToggle(property: string, icon: string, values: any[]) {
+  async addToggle(property: string, icon: string, values: any[], isWorkspace?: boolean) {
     const items: ToggleSetting[] = this.config.get('items') || [];
-    items.push({ property, icon, values });
+    items.push({ property, icon, values, isWorkspace });
     await this.config.update('items', items, vscode.ConfigurationTarget.Global);
   }
 
@@ -188,6 +201,12 @@ class TestExtensionManager {
     return vscode.workspace.getConfiguration().get(property);
   }
 
+  /** Get the workspace value of a property from the configuration */
+  getWorkspaceValueFromConf(property: string): unknown {
+    const configData = vscode.workspace.getConfiguration().inspect(property);
+    return configData?.workspaceValue;
+  }
+
   /** Get the all status bar items */
   getAllTogglesFromConf(): ToggleSetting[] {
     return this.config.get('items') as ToggleSetting[];
@@ -198,6 +217,14 @@ class TestExtensionManager {
     // TODO: how to clear `EXTENSION_NAME` property all at once instead of one by one?
     await this.config.update('items', undefined, vscode.ConfigurationTarget.Global);
     await this.config.update('enabled', undefined, vscode.ConfigurationTarget.Global);
+    
+    // Clear any test property configured in tests to not affect other tests
+    await vscode.workspace.getConfiguration().update('editor.renderWhitespace', undefined, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration().update('editor.renderWhitespace', undefined, vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration().update('editor.cursorStyle', undefined, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration().update('editor.cursorStyle', undefined, vscode.ConfigurationTarget.Global);
+    await vscode.workspace.getConfiguration().update('editor.rulers', undefined, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace.getConfiguration().update('editor.rulers', undefined, vscode.ConfigurationTarget.Global);
   }
 
   /** Get the configuration for the extension */


### PR DESCRIPTION
## Description
This PR adds an `isWorkspace` boolean flag to the extension items. When set to `true`, the configuration will be toggled at the project workspace level instead of globally.

## Summary of Changes
- **New Schema Property:** Added `isWorkspace` to [package.json](cci:7://file:///home/mhagnumdw/projetos/vscode-easy-toggle-settings/package.json:0:0-0:0) configurations (defaults to `false`).
- **Target Selection:** Updated [ExtensionManager.ts](cci:7://file:///home/mhagnumdw/projetos/vscode-easy-toggle-settings/src/ExtensionManager.ts:0:0-0:0) to switch between Global and Workspace configuration targets.
- **Enhanced Testing:** Configured `vscode-test` to use a dummy workspace and added integration tests to verify scoped configuration updates.
