### PR TITLE
feat: Add `disabledValue` property to gray out status bar items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## 1.3.0
 
 - Feat: Add support for workspace-level setting toggles with the `isWorkspace` property (PR #80)
+- Feat: Add `disabledValue` property to gray out the status bar item when a specific value is reached
 
 ## 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## 1.3.0
 
 - Feat: Add support for workspace-level setting toggles with the `isWorkspace` property (PR #80)
-- Feat: Add `disabledValue` property to gray out the status bar item when a specific value is reached
+- Feat: Add `disabledValue` property to gray out the status bar item when a specific value is reached (PR #81)
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This extension contributes the following settings:
   - `icon` (`string`): [Codicon](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing) icon name (e.g., `eye`, `whitespace`)
   - `values` (`array`): At least two unique values to cycle through
   - `isWorkspace` (`boolean`, optional): Toggles the setting at the workspace level instead of globally (default: `false`)
+  - `disabledValue` (`any`, optional): If the setting reaches this value (must be one of the `values`), the status bar icon will appear disabled/grayed out
 
 ## Release Notes
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
                 "description": "If true, the setting will be toggled at the workspace level instead of globally",
                 "default": false
               },
+              "disabledValue": {
+                "description": "If the setting reaches this value, the status bar icon will appear disabled/grayed out"
+              },
               "values": {
                 "type": "array",
                 "description": "List of possible values for this setting",

--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -20,6 +20,8 @@ export interface ToggleSetting {
   icon: string;
   /** If true, the setting will be toggled at the workspace level */
   isWorkspace?: boolean;
+  /** If the setting reaches this value, the status bar item will appear grayed out */
+  disabledValue?: any;
 }
 
 /**
@@ -189,6 +191,13 @@ export class ExtensionManager {
     const suffix = setting.isWorkspace ? ' (workspace)' : '';
     item.text = `$(${setting.icon})`;
     item.tooltip = `${setting.property}: ${value}${suffix}`;
+
+    if (setting.disabledValue !== undefined && JSON.stringify(value) === JSON.stringify(setting.disabledValue)) {
+      item.color = new vscode.ThemeColor('disabledForeground');
+    } else {
+      item.color = undefined;
+    }
+
     item.show();
   }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -89,6 +89,16 @@ suite('Extension Test Suite', () => {
     assert.strictEqual(extension.getWorkspaceValueFromConf('editor.renderWhitespace'), 'none');
   });
 
+  test('Add toggle with disabledValue', async () => {
+    await extension.addToggle('editor.renderWhitespace', 'whitespace', ["none", "all"], false, "none");
+
+    await extension.click('editor.renderWhitespace');
+    assert.strictEqual(extension.getValueFromConf('editor.renderWhitespace'), 'none');
+
+    await extension.click('editor.renderWhitespace');
+    assert.strictEqual(extension.getValueFromConf('editor.renderWhitespace'), 'all');
+  });
+
   test('Add duplicate toggle', async () => {
     const showWarningMessageSpy = sinon.spy(vscode.window, 'showWarningMessage');
 
@@ -168,9 +178,9 @@ suite('Extension Test Suite', () => {
 class TestExtensionManager {
 
   /** Simulate the user adding a toggle */
-  async addToggle(property: string, icon: string, values: any[], isWorkspace?: boolean) {
+  async addToggle(property: string, icon: string, values: any[], isWorkspace?: boolean, disabledValue?: any) {
     const items: ToggleSetting[] = this.config.get('items') || [];
-    items.push({ property, icon, values, isWorkspace });
+    items.push({ property, icon, values, isWorkspace, disabledValue });
     await this.config.update('items', items, vscode.ConfigurationTarget.Global);
   }
 


### PR DESCRIPTION
Add `disabledValue` property to gray out status bar items when a setting reaches a specific value.